### PR TITLE
Adding `val` to the interface to support bootstrap tags input

### DIFF
--- a/bootstrap3-typeahead.js
+++ b/bootstrap3-typeahead.js
@@ -409,8 +409,10 @@
     mouseleave: function (e) {
       this.mousedover = false;
       if (!this.focused && this.shown) this.hide();
+    },
+    val: function (newVal) {
+      this.$element.val(newVal)
     }
-
   };
 
 


### PR DESCRIPTION
When clearing the input bootstrap tags input sends the empty string to the `val` function.  This causes an error in the console.  This is a quick fix to the problem.
